### PR TITLE
fs_config: Fix cases without vendor/oem partition

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -3123,6 +3123,8 @@ endef
 
 ifdef TARGET_NEEDS_DTBOIMAGE
 INSTALLED_DTBOIMAGE_TARGET := $(PRODUCT_OUT)/dtbo.img
+else ifdef BOARD_KERNEL_SEPARATED_DTBO
+INSTALLED_DTBOIMAGE_TARGET := $(PRODUCT_OUT)/dtbo.img
 endif
 
 # -----------------------------------------------------------------

--- a/tools/fs_config/Android.mk
+++ b/tools/fs_config/Android.mk
@@ -99,7 +99,7 @@ $(LOCAL_BUILT_MODULE): $(LOCAL_PATH)/fs_config_generator.py $(TARGET_FS_CONFIG_G
 	   --aid-header $(PRIVATE_ANDROID_FS_HDR) \
 	   --capability-header $(PRIVATE_ANDROID_CAP_HDR) \
 	   --partition system \
-	   --all-partitions $(subst $(space),$(comma),$(PRIVATE_PARTITION_LIST)) \
+	   --all-partitions "$(subst $(space),$(comma),$(PRIVATE_PARTITION_LIST))" \
 	   --dirs \
 	   --out_file $@ \
 	   $(or $(PRIVATE_TARGET_FS_CONFIG_GEN),/dev/null)
@@ -124,7 +124,7 @@ $(LOCAL_BUILT_MODULE): $(LOCAL_PATH)/fs_config_generator.py $(TARGET_FS_CONFIG_G
 	   --aid-header $(PRIVATE_ANDROID_FS_HDR) \
 	   --capability-header $(PRIVATE_ANDROID_CAP_HDR) \
 	   --partition system \
-	   --all-partitions $(subst $(space),$(comma),$(PRIVATE_PARTITION_LIST)) \
+	   --all-partitions "$(subst $(space),$(comma),$(PRIVATE_PARTITION_LIST))" \
 	   --files \
 	   --out_file $@ \
 	   $(or $(PRIVATE_TARGET_FS_CONFIG_GEN),/dev/null)

--- a/tools/fs_config/fs_config_generator.py
+++ b/tools/fs_config/fs_config_generator.py
@@ -1004,10 +1004,6 @@ class FSConfigGen(BaseGenerator):
 
         self._partition = args['partition']
         self._all_partitions = args['all_partitions']
-        if self._partition == 'system' and self._all_partitions is None:
-            sys.exit(
-                'All other partitions must be provided if generating output'
-                ' for the system partition')
 
         self._out_file = args['out_file']
 

--- a/tools/releasetools/edify_generator.py
+++ b/tools/releasetools/edify_generator.py
@@ -156,8 +156,9 @@ class EdifyGenerator(object):
            ");")
     self.script.append(self.WordWrap(cmd))
 
-  def RunBackup(self, command):
-    self.script.append(('run_program("/tmp/install/bin/backuptool.sh", "%s");' % command))
+  def RunBackup(self, command, system_path):
+    self.script.append(('run_program("/tmp/install/bin/backuptool.sh", "%s", "%s");' % (
+        command, system_path)))
 
   def RunCleanCache(self):
     self.script.append(('run_program("/system/bin/clean_cache.sh");'))

--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -968,9 +968,14 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
   script.SetPermissionsRecursive("/tmp/install/bin", 0, 0, 0755, 0755, None, None)
 
   if OPTIONS.backuptool:
+    is_system_as_root = script.fstab["/system"].mount_point == "/"
+    if is_system_as_root:
+      script.fstab["/system"].mount_point = "/system"
     script.Mount("/system")
-    script.RunBackup("backup")
+    script.RunBackup("backup", "/system/system" if is_system_as_root else "/system")
     script.Unmount("/system")
+    if is_system_as_root:
+      script.fstab["/system"].mount_point = "/"
 
   system_progress = 0.75
 
@@ -1031,9 +1036,14 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
 
   if OPTIONS.backuptool:
     script.ShowProgress(0.02, 10)
+    is_system_as_root = script.fstab["/system"].mount_point == "/"
+    if is_system_as_root:
+      script.fstab["/system"].mount_point = "/system"
     script.Mount("/system")
-    script.RunBackup("restore")
+    script.RunBackup("restore", "/system/system" if is_system_as_root else "/system")
     script.Unmount("/system")
+    if is_system_as_root:
+      script.fstab["/system"].mount_point = "/"
 
   script.Mount("/system")
   script.RunCleanCache()


### PR DESCRIPTION
If the device has neither an OEM nor a vendor partiton,
$PRIVATE_PARTITION_LIST will be empty, causing the fsconfig tool to fail
because the "--all-partitions" argument will be empty.

Quote the comma-substituted "$(PRIVATE_PARTITION_LIST)" - which may be
empty - to appease argparse, which will then populate "_all_partitions"
with an empty "str" object.

Checking _all_partitions against None is superfluous since either
argparse will catch the empty argument and fail early, or the argument
will be a string, in which case it will not be None.

Signed-off-by: Felix <google@ix5.org>
Change-Id: I236e30445b303b4945467b5dc4387d54b5d984f9